### PR TITLE
Remove debounceTime

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "ms-vscode.vscode-typescript-tslint-plugin"
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,35 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    // Columns at which to show vertical rulers
-    "editor.rulers": [140],
-
-    "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  // Hide files from file explorer.
+  "files.exclude": {
+    "node_modules/": true,
+    ".skypageslocales": true,
+    ".skypagestmp": true,
+    "dist": true
+  },
+  // Exclude files from editor watchers.
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/dist/**": true,
+    "**/node_modules/**": true,
+    "**/.skypageslocales/**": true,
+    "**/.skypagestmp/**": true
+  },
+  // Exclude files from editor searches.
+  "search.exclude": {
+    "**/dist": true,
+    "**/node_modules": true,
+    "**/.skypageslocales/**": true,
+    "**/.skypagestmp/**": true,
+    "package-lock.json": true
+  },
+  "editor.rulers": [
+    140
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.tslint": true
+  }
 }

--- a/src/app/public/modules/autonumeric/autonumeric.directive.spec.ts
+++ b/src/app/public/modules/autonumeric/autonumeric.directive.spec.ts
@@ -42,7 +42,7 @@ describe('Autonumeric directive', () => {
   // #region helpers
   function detectChanges(): void {
     fixture.detectChanges();
-    tick(250);
+    tick();
   }
 
   function getReactiveInput(): HTMLInputElement {

--- a/src/app/public/modules/autonumeric/autonumeric.directive.ts
+++ b/src/app/public/modules/autonumeric/autonumeric.directive.ts
@@ -122,22 +122,19 @@ export class SkyAutonumericDirective implements OnInit, OnDestroy, ControlValueA
   }
 
   /**
-   * Implemented as part of ControlValueAccessor.
+   * Function that is called by the forms API when the control status changes to or from 'DISABLED'.
+   * Depending on the status, it enables or disables the appropriate DOM element.
    */
-  public setDisabledState(value: boolean): void {
-    this.renderer.setProperty(this.nativeElement, 'disabled', value);
+  public setDisabledState(isDisabled: boolean): void {
+    this.renderer.setProperty(this.nativeElement, 'disabled', isDisabled);
   }
 
-  /**
-   * This method is called by the forms API to write to the
-   * view when programmatic changes from model to view are requested.
-   */
+  /** This method is called by the forms API to write to the view when programmatic changes from model to view are requested. */
   public writeValue(value: number): void {
     if (this.value !== value) {
       this.value = value;
       this.onChange(value);
 
-      // Mark the control as "pristine" if it is initialized with a value.
       const initializedWithValue = this.isFirstChange && this.control && this.value !== null;
       if (initializedWithValue) {
         this.isFirstChange = false;

--- a/src/app/visual/autonumeric/autonumeric-visual.component.html
+++ b/src/app/visual/autonumeric/autonumeric-visual.component.html
@@ -66,6 +66,24 @@
     Valid: {{ donationAmount.valid }}
   </div>
 
+  <!-- Currency Example - https://github.com/blackbaud/skyux-autonumeric/issues/17 -->
+  <div>
+    <h2>Currency example</h2>
+    <form [formGroup]="formGroup">
+      <input
+        class="sky-form-control"
+        formControlName="currency"
+        type="text"
+        [skyAutonumeric]="{ currencySymbol: '$', decimalPlaces: 2 }"
+      />
+    </form>
+    <div>Value: {{formGroup.controls.currency.value}}</div>
+    <div>Dirty: {{formGroup.controls.currency.dirty}}</div>
+    <div>Pristine: {{formGroup.controls.currency.pristine}}</div>
+    <div>Touched: {{formGroup.controls.currency.touched}}</div>
+    <div>Valid: {{formGroup.controls.currency.valid}}</div>
+  </div>
+
   <h2>
     Modify value and state
   </h2>
@@ -105,8 +123,16 @@
   <button
     class="sky-btn"
     type="button"
+    (click)="setOptionsToCustom()"
+  >Set options to custom</button>
+
+  <button
+    class="sky-btn"
+    type="button"
     (click)="onDisableClick()"
   >
     Toggle disabled
   </button>
+
+  <pre>{{ autonumericOptions | json }}</pre>
 </div>

--- a/src/app/visual/autonumeric/autonumeric-visual.component.ts
+++ b/src/app/visual/autonumeric/autonumeric-visual.component.ts
@@ -60,6 +60,8 @@ export class AutonumericVisualComponent implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.formGroup = this.formBuilder.group({
+      // tslint:disable-next-line: no-null-keyword
+      currency: new FormControl(null, [Validators.required]),
       donationAmount: new FormControl(1000, [Validators.required])
     });
 
@@ -97,6 +99,14 @@ export class AutonumericVisualComponent implements OnInit, OnDestroy {
 
   public setOptionsByPreset(): void {
     this.autonumericOptions = 'Chinese';
+  }
+
+  public setOptionsToCustom(): void {
+    this.autonumericOptions = {
+      currencySymbol: '#',
+      currencySymbolPlacement: 's',
+      decimalPlaces: 3
+    };
   }
 
   public onDisableClick(): void {


### PR DESCRIPTION
After talking to Steve we decided to try removing debounceTime. I will probably end up closing Draft PR #44 in favor of this simplified PR.  

I looked at the original issue (#17) around why the debounecTime code was added and replicated the description in the visual with debounceTime removed. Everything _seemed_ fine but perhaps Alex should double-check since he originally created the issue.

## Why?
- In an AG Grid with a `skyux-autonumeric` editor if you change a value and tab quick enough the value isn't committed.
- I believe the `debounceTime(250)` combined with leaving the cell causes AG Grid to destroy the control before the final value is propogated.


## Changes
**Directive**
- Removed `debounceTime(250)`.
- Moved the parse input value logic into helper functions.
  - Altered the "_is the input value just the currency symbol_" logic to default to an empty string if the settings aren't defined yet.
- Tiny improvements
  - Added missing `ngOnDestroy`
  - Extracted logic into descriptive variables
  - Explicitly returning `null` when there are no validation errors instead of the implicit `undefined`.
  - Added Angular's interface comments to the `IControlValueAccessor` functions.

**Directive Test**
- Removed `250` from tick since we do not need to simulate the passage of time for debounceTime.

**Misc**
- Added visual for the Github Issue (#17) that I believe the currency symbol parsing was originally added.
- Added missing .vscode project files