### PR TITLE
Use `esModuleInterop`

### DIFF
--- a/projects/sky-autonumeric/src/modules/autonumeric/autonumeric.directive.ts
+++ b/projects/sky-autonumeric/src/modules/autonumeric/autonumeric.directive.ts
@@ -36,7 +36,7 @@ import {
   SkyAutonumericOptionsProvider
 } from './autonumeric-options-provider';
 
-const AutoNumeric = require("autonumeric")
+import AutoNumeric from 'autonumeric';
 
 // tslint:disable:no-forward-ref no-use-before-declare
 const SKY_AUTONUMERIC_VALUE_ACCESSOR = {
@@ -74,7 +74,7 @@ export class SkyAutonumericDirective implements OnInit, OnDestroy, ControlValueA
     this.updateAutonumericInstance();
   }
 
-  private autonumericInstance: typeof AutoNumeric;
+  private autonumericInstance: AutoNumeric;
   private autonumericOptions: SkyAutonumericOptions;
   private control: AbstractControl;
   private isFirstChange = true;
@@ -202,7 +202,7 @@ export class SkyAutonumericDirective implements OnInit, OnDestroy, ControlValueA
    */
   private isInputValueTheCurrencySymbol(inputValue: string): boolean {
     /* istanbul ignore next */
-    const currencySymbol = ((this.autonumericOptions as typeof AutoNumeric.Options)?.currencySymbol ?? '').trim();
+    const currencySymbol = ((this.autonumericOptions as AutoNumeric.Options)?.currencySymbol ?? '').trim();
     return (currencySymbol && inputValue === currencySymbol);
   }
 
@@ -215,7 +215,7 @@ export class SkyAutonumericDirective implements OnInit, OnDestroy, ControlValueA
   }
 
   private updateAutonumericInstance(): void {
-    this.autonumericInstance.update(this.autonumericOptions as typeof AutoNumeric.Options);
+    this.autonumericInstance.update(this.autonumericOptions as AutoNumeric.Options);
   }
 
   private mergeOptions(value: SkyAutonumericOptions): SkyAutonumericOptions {
@@ -224,7 +224,7 @@ export class SkyAutonumericDirective implements OnInit, OnDestroy, ControlValueA
     let newOptions: SkyAutonumericOptions = {};
     if (typeof value === 'string') {
       const predefinedOptions = AutoNumeric.getPredefinedOptions();
-      newOptions = predefinedOptions[value as keyof typeof AutoNumeric.Options] as typeof AutoNumeric.Options;
+      newOptions = predefinedOptions[value as keyof AutoNumeric.Options] as AutoNumeric.Options;
     } else {
       newOptions = value;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "importHelpers": true,
     "target": "es2017",
     "module": "es2020",


### PR DESCRIPTION
Using `import` is the preferred way to import ES6 modules into our Angular libraries. Angular CLI doesn't like `require` statements.

The `autoNumeric` library gave a few hints on how to accomplish this in their source code:
https://github.com/autoNumeric/autoNumeric/blob/next/index.d.ts#L6-L9